### PR TITLE
fix type error for queue type

### DIFF
--- a/inc/nr_micro_shell.h
+++ b/inc/nr_micro_shell.h
@@ -69,7 +69,7 @@ extern "C"
         unsigned short int store_rear;
         unsigned short int store_num;
 
-        char queue[NR_SHELL_MAX_CMD_HISTORY_NUM + 1];
+        unsigned char queue[NR_SHELL_MAX_CMD_HISTORY_NUM + 1];
         char buf[NR_SHELL_CMD_HISTORY_BUF_LENGTH + 1];
 
     } shell_his_queue_st;


### PR DESCRIPTION
 record to char will cause queue->store_num calc error when char to
negative value @shell_his_queue_add_cmd

queue->store_num -= queue->queue[queue->fp] - queue->store_front;

Char -> short int  -> unsigned short int, cause error er: 0xff -> 0xFFFF 