### PR TITLE
refactor: improve build system and shell configuration

### DIFF
--- a/examples/linux_with_mini_config/makefile
+++ b/examples/linux_with_mini_config/makefile
@@ -1,6 +1,6 @@
 CC := gcc
 CCFLAG :=
-DGBFLAG := -g -fprofile-arcs -ftest-coverage
+DGBFLAG := -g
 CCOBJFLAG := $(CCFLAG) -c
 
 BIN_PATH := out
@@ -25,7 +25,7 @@ default : all
 .PHONY: all
 all:
 	@rm -f $(TARGET)
-	$(CC) $(CCFLAG) $(INC) $(SRC) -o $(TARGET) -l curses
+	$(CC) $(CCFLAG) $(INC) $(SRC) -o $(TARGET)
 
 .PHONY: debug
 debug: 

--- a/examples/simulator/makefile
+++ b/examples/simulator/makefile
@@ -1,6 +1,6 @@
 CC := gcc
 CCFLAG :=
-DGBFLAG := -g -fprofile-arcs -ftest-coverage --coverage -lgcov -D NR_DEBUG_BIN -fPIC -O0
+DGBFLAG := -g -fprofile-arcs -ftest-coverage --coverage -lgcov -D NR_DEBUG_BIN -fPIC -fsanitize=address
 CCOBJFLAG := $(CCFLAG) -c
 
 BIN_PATH := out
@@ -26,12 +26,11 @@ default : all
 .PHONY: all
 all:
 	@rm -f $(TARGET)
-	$(CC) $(CCFLAG) $(INC) -D NR_MICRO_SHELL_SIMULATOR $(SRC) -o $(TARGET) -l curses
-
+	$(CC) $(CCFLAG) $(INC) $(SRC) -o $(TARGET)
 .PHONY: debug
 debug:
 	@rm -f $(TARGET_DEBUG)
-	$(CC) $(CCFLAG) $(DGBFLAG) $(INC) -D NR_MICRO_SHELL_SIMULATOR $(SRC) -o $(TARGET_DEBUG) -l curses
+	$(CC) $(CCFLAG) $(DGBFLAG) $(INC) $(SRC) -o $(TARGET_DEBUG)
 
 .PHONY: clean
 clean:

--- a/examples/simulator/nr_micro_shell_port.h
+++ b/examples/simulator/nr_micro_shell_port.h
@@ -35,24 +35,28 @@ extern "C" {
 
 /* Required configuration macros */
 #define shell_putc(x) putchar((x))
-#define NR_SHELL_MAX_LINE_SZ 80
-#define NR_SHELL_PROMPT "nr@dev"
-#define NR_SHELL_MAX_PARAM_NUM 16
 
 /* Optional configuration macros */
+#define NR_SHELL_MAX_LINE_SZ 80 /* Maximum command line length */
+#define NR_SHELL_PROMPT "nr@dev" /* Command prompt string */
+#define NR_SHELL_MAX_PARAM_NUM 16 /* Maximum number of parameters per command */
 
-#define NR_SHELL_SHOW_LOGO
+#define NR_SHELL_CMD_WR /* Enable write command support */
+#define NR_SHELL_CMD_RD /* Enable read command support */
+#define NR_SHELL_CMD_HEX2DEC /* Enable hexadecimal to decimal conversion */
 
-#define NR_SHELL_AUTO_COMPLETE_SUPPORT
+#define NR_SHELL_SHOW_LOGO /* Enable shell logo display */
 
-#define NR_SHELL_HISTORY_CMD_SUPPORT
-#define NR_SHELL_HISTORY_CMD_NUM 5
-#define NR_SHELL_HISTORY_CMD_SZ 64
+#define NR_SHELL_AUTO_COMPLETE_SUPPORT /* Enable command auto-completion feature */
+
+#define NR_SHELL_HISTORY_CMD_SUPPORT /* Enable command history feature */
+#define NR_SHELL_HISTORY_CMD_NUM 5 /* Number of commands to keep in history */
+#define NR_SHELL_HISTORY_CMD_SZ 64 /* Maximum size of each history command */
 
 uint64_t get_sys_timestamp(void);
-#define shell_get_ts() get_sys_timestamp()
+#define shell_get_ts() get_sys_timestamp() /* Macro to get current system timestamp */
 
-#define NR_SHELL_DEBUG
+#define NR_SHELL_DEBUG /* Enable debug logging functionality for the shell */
 
 #ifdef NR_SHELL_DEBUG
 extern FILE *dbug_log;
@@ -61,7 +65,6 @@ extern FILE *key_rec_log;
 #define KEY_RECORD(c) fprintf(key_rec_log, "%x ", c)
 void nr_shell_debug_log_init(void);
 #endif
-
 
 #ifdef __cplusplus
 }

--- a/examples/simulator/simulator.c
+++ b/examples/simulator/simulator.c
@@ -5,16 +5,10 @@
 #include <stdint.h>
 #include "nr_micro_shell.h"
 
-#ifdef NR_DEBUG_BIN
-#include <gcov.h>
-#endif
-
 int main(int argc, char *argv[])
 {
 	int c;
-#ifdef NR_DEBUG_BIN
 	int i = 0;
-#endif
 
 	system("stty -echo");
 	system("stty -icanon");
@@ -22,8 +16,6 @@ int main(int argc, char *argv[])
 	while (1) {
 		c = getchar();
 		shell(c);
-#ifdef NR_DEBUG_BIN
-	 	// __gcov_dump();
 		if (c == 'q') {
 			i++;
 		} else {
@@ -33,7 +25,6 @@ int main(int argc, char *argv[])
 		if (i > 3) {
 			break;
 		}
-#endif
 	}
 	system("stty echo");
 	system("stty icanon");

--- a/inc/nr_micro_shell.h
+++ b/inc/nr_micro_shell.h
@@ -32,6 +32,8 @@ extern "C" {
 
 #include "nr_micro_shell_port.h"
 
+#define NR_SHELL_VERSION "2.0.0"
+
 /* Default config */
 #ifndef NR_SHELL_MAX_LINE_SZ
 #define NR_SHELL_MAX_LINE_SZ 80

--- a/src/nr_micro_shell_cmds.c
+++ b/src/nr_micro_shell_cmds.c
@@ -148,7 +148,7 @@ int cmd_wr(uint8_t argc, char **argv)
 }
 #endif
 
-#ifndef NR_SHELL_CMD_HEX2DEC
+#ifdef NR_SHELL_CMD_HEX2DEC
 int cmd_hex2dec(uint8_t argc, char **argv)
 {
 	uint32_t value;

--- a/src/nr_micro_shell_core.c
+++ b/src/nr_micro_shell_core.c
@@ -644,7 +644,7 @@ void shell_init(void)
 	shell_printf("| |\\  |  _ <  | |  | | | (__| | | (_) |  ___) | | | |  __/ | |\r\n");
 	shell_printf("|_| \\_|_| \\_\\ |_|  |_|_|\\___|_|  \\___/  |____/|_| |_|\\___|_|_|\r\n");
 	shell_printf("                                                              \r\n");
-	shell_printf("Welcome to the nr_micro_shell! build time %s %s\r\n", __DATE__, __TIME__);
+	shell_printf("Welcome to the nr_micro_shell v%s! Build time %s %s\r\n", NR_SHELL_VERSION, __DATE__, __TIME__);
 #endif
 	print_prompt(&_default_sh);
 }


### PR DESCRIPTION
- Remove curses library dependency from build system
- Add AddressSanitizer support for debug builds
- Improve documentation for shell configuration macros
- Add version information (v2.0.0) to shell header
- Fix conditional compilation for hex2dec command
- Clean up debug-related code in simulator
- Remove unnecessary gcov coverage profiling flags